### PR TITLE
Update GPT-4 Vision Preview model to GPT-4o

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -99,8 +99,8 @@ export const Models = {
   //   desc: 'ChatGPT (GPT-4-Turbo 128k 0125 Preview)',
   // },
   chatgptApi4_v_preview: {
-    value: 'gpt-4-vision-preview',
-    desc: 'Chatgpt-4v preview model',
+    value: 'gpt-4o',
+    desc: 'Chatgpt-4o',
   },
 
   // claude2WebFree: { value: 'claude-2.1', desc: 'Claude.ai (Web, Claude 2.1)' },


### PR DESCRIPTION
This pull request updates the model configuration for the `chatgptApi4_v_preview` option. The changes are as follows:

- Changed the model value from 'gpt-4-vision-preview' to 'gpt-4o'
- Updated the description from 'Chatgpt-4v preview model' to 'Chatgpt-4o'

This update aims to replace the GPT-4 Vision Preview model with the GPT-4o model, which may offer different capabilities or performance characteristics. This change will affect how the application interacts with the OpenAI API and potentially alter the functionality related to this model option.